### PR TITLE
docs: show compacted menu

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -138,7 +138,7 @@ navbar_logo = true
 # Set to true if you don't want the top navbar to be translucent when over a `block/cover`, like on the homepage.
 navbar_translucent_over_cover_disable = false
 # Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = false
+sidebar_menu_compact = true
 # Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
 sidebar_search_disable = false
 


### PR DESCRIPTION
## What this PR changes/adds

Set menu compact that will permit to keep the menu compacted by default:
![Screenshot_20240930_140403](https://github.com/user-attachments/assets/c9960e1a-a344-4ced-95c8-aaaf36e035b0)


Instead of the current:
![Screenshot_20240930_140248](https://github.com/user-attachments/assets/8593ca2c-988e-420b-a852-81fa522c1067)


## Why it does that

Improve readability

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
