### PR TITLE
chore: amend PR etiquette document

### DIFF
--- a/content/en/documentation/for-contributors/guidelines/pr-etiquette/_index.md
+++ b/content/en/documentation/for-contributors/guidelines/pr-etiquette/_index.md
@@ -11,7 +11,8 @@ important things to note for a successful contribution. Choosing an area to work
 successful pull request.
 
 As with any other open-source project, it is generally good practice to start out with some relatively low-impact
-contributions like documentation, fixing some minor bugs or generally issues with `good first issue` label on them.
+contributions like documentation, fixing some minor bugs or generally issues with `good first issue` label on them, 
+check [this page](https://github.com/search?q=org%3Aeclipse-edc+label%3A%22good+first+issue%22+state%3Aopen&type=issues&ref=advsearch).
 That way we (the committers) get to know you, we can build trust, and you'll get to know the code base better.
 
 It is **not recommended** to start your journey with high-impact contributions such as changes to core modules, changes

--- a/content/en/documentation/for-contributors/guidelines/pr-etiquette/_index.md
+++ b/content/en/documentation/for-contributors/guidelines/pr-etiquette/_index.md
@@ -3,7 +3,46 @@ title: Pull Request Etiquette
 linkTitle: PR Etiquette
 weight: 20
 ---
-## Authors
+
+## Choosing an area to work on
+
+We welcome all contributions, after all, they are what keep the project alive and active. However, there are a few
+important things to note for a successful contribution. Choosing an area to work on is a key aspect for a
+successful pull request.
+
+As with any other open-source project, it is generally good practice to start out with some relatively low-impact
+contributions like documentation, fixing some minor bugs or generally issues with `good first issue` label on them.
+That way we (the committers) get to know you, we can build trust, and you'll get to know the code base better.
+
+It is **not recommended** to start your journey with high-impact contributions such as changes to core modules, changes
+that cut across several modules or that generally bring a very large changeset. Start small, work your way in from
+there.
+
+Most importantly, it is **always** required to open a discussion or an issue first.
+
+## Before opening a pull request
+
+Pull requests **must** be linked to an issue that has already gone through the triage process. In most cases, the
+general triage process looks like this:
+
+- open a discussion, wait for comments
+- committers comment and possibly convert the discussion to an issue labelled with `triage`
+- you might be asked to provide more details or even a solution proposal in the issue
+- issue triage happens, at which point the `triage` label is removed
+- now the issue is ready for implementation
+
+Issues from external contributors, i.e. contributors that aren't committers, require a _sponsor_. A sponsor is a
+committer who will provide technical guidance and work with you on a solution proposal and who will represent the
+feature in the technical committee. Sponsors should also be put on as reviewers to the pull request, although they might
+request a second review from another committer (four eyes principle).
+
+Sponsorship can be obtained through engagement on discussions or issues.
+
+
+> Pull requests, that are not linked to a properly triaged issue might be ignored or get closed without notice,
+> regardless of the author or the content!
+
+## For PR Authors
 
 PRs should adhere to the following rules.
 
@@ -27,11 +66,15 @@ PRs should adhere to the following rules.
 - If you require a reviewer's input while it's still in draft, please contact the designated reviewer using
   the `@mention` feature and let them know what you'd like them to look at.
 - Request a review from one of the [technical committers](pr_etiquette.md#the-technical-committers). Requesting a review
-  from anyone else is still possible, and
-  sometimes may be advisable, but only committers can merge PRs, so be sure to include them early on.
-- Re-request reviews after all remarks have been adopted. This helps reviewers track their work in GitHub.
+  from anyone else is still possible, and sometimes may be advisable, but only committers can merge PRs, so be sure to
+  include them early on.
+- Re-request reviews after all remarks have been adopted. This helps reviewers track their work in GitHub. Failing to do
+  that might cause your PR to stale out.
+- Carefully read all review comments and be sure to incorporate them. It is very exhausting for reviewers to have to
+  repeat themselves, and it might be grounds for them to close the PR.
 - If you disagree with a committer's remarks, feel free to object and argue, but if no agreement is reached, you'll have
-  to either accept the committer's decision or withdraw your PR.
+  to either accept the committer's decision or withdraw your PR. Reviewers may also close the PR if they feel their
+  directions aren't followed.
 - Be civil and objective. No foul language, insulting or otherwise abusive language will be tolerated.
 - The PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
     - The title must follow the format as `<type>(<optional scope>): <description>`.
@@ -42,13 +85,12 @@ PRs should adhere to the following rules.
   See [check-pull-request-title job of GitHub workflow](https://github.com/eclipse-edc/.github/blob/main/.github/workflows/scan-pull-request.yml)
   for checking details.
 
-## Reviewers
+## For PR Reviewers
 
 - Please complete reviews within two business days or delegate to another committer, removing yourself as a reviewer.
 - If you have been requested as reviewer, but cannot do the review for any reason (time, lack of knowledge in particular
   area, etc.) please comment that in the PR and remove yourself as a reviewer, suggesting a stand-in. The **CODEOWNERS**
-  document
-  should help with that.
+  document should help with that.
 - Don't be overly pedantic.
 - Don't argue basic principles (code style, architectural decisions, etc.)
 - Use the `suggestion` feature of GitHub for small/simple changes.


### PR DESCRIPTION
## What this PR changes/adds

Amends the PR etiquette document as per committer discussion from Jan 22nd, 2025

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
