### PR TITLE
fix(search): removes GCSE and enable offline search

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -117,10 +117,10 @@ github_project_repo = "https://github.com/eclipse-edc"
 github_branch = "main"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-gcs_engine_id = "d72aa9b2712488cc3"
+# gcs_engine_id = "d72aa9b2712488cc3"
 
 # Enable Lunr.js offline search
-offlineSearch = false
+offlineSearch = true
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = false


### PR DESCRIPTION
## What this PR changes/adds

Fixes the docs search by disabling the [GCSE](https://www.docsy.dev/docs/adding-content/search/#configure-search-with-a-google-custom-search-engine) plugin and enabling the offline search one. 

## Why it does that

search is broken


