### PR TITLE
docs: update CONTRIBUTING.md by removing google CLA references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,15 +3,15 @@
 We'd love to accept your patches and contributions to this project. There are
 just a few small guidelines you need to follow.
 
-## Contributor License Agreement
+## Eclipse Contributor Agreement
 
-Contributions to this project must be accompanied by a Contributor License
-Agreement. You (or your employer) retain the copyright to your contribution;
+Contributions to this project must be accompanied by an Eclipse Contributor Agreement (ECA).
+You (or your employer) retain the copyright to your contribution;
 this simply gives us permission to use and redistribute your contributions as
-part of the project. Head over to <https://cla.developers.google.com/> to see
-your current agreements on file or to sign a new one.
+part of the project. Head over to <https://www.eclipse.org/projects/handbook/#specifications-contributors> to understand
+how to sign the ECA.
 
-You generally only need to submit a CLA once, so if you've already submitted one
+You generally only need to submit the ECA once, so if you've already submitted one
 (even if it was for a different project), you probably don't need to do it
 again.
 
@@ -22,7 +22,6 @@ use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
 
-## Community Guidelines
+## Contribution Guidelines
 
-This project follows
-[Google's Open Source Community Guidelines](https://opensource.google.com/conduct/).
+Head over to the [Eclipse EDC Documentation](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/) to understand the contribution guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,3 @@
-# How to Contribute
-
-We'd love to accept your patches and contributions to this project. There are
-just a few small guidelines you need to follow.
-
-## Eclipse Contributor Agreement
-
-Contributions to this project must be accompanied by an Eclipse Contributor Agreement (ECA).
-You (or your employer) retain the copyright to your contribution;
-this simply gives us permission to use and redistribute your contributions as
-part of the project. Head over to <https://www.eclipse.org/projects/handbook/#specifications-contributors> to understand
-how to sign the ECA.
-
-You generally only need to submit the ECA once, so if you've already submitted one
-(even if it was for a different project), you probably don't need to do it
-again.
-
-## Code reviews
-
-All submissions, including submissions by project members, require review. We
-use GitHub pull requests for this purpose. Consult
-[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
-information on using pull requests.
-
-## Contribution Guidelines
+# Contribution Guidelines
 
 Head over to the [Eclipse EDC Documentation](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/) to understand the contribution guidelines.


### PR DESCRIPTION
## What this PR changes/adds

This PR changes the CONTRIBUTING.md. The file instructed cutributors to sign Google's CLA instead of the correct ECA (Eclipse Contributor Agreement)
## Why it does that

I believe the file was created by some automated scaffolding script, which refers to Google's CLA.

⚠️ **I updated the bare minimum in order to refer to the ECA and the Contributor guidelines on [eclipse-edc.github.io](https://eclipse-edc.github.io). There may be something else missing that I might not be aware of.**

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

@ndr-brt 

## Linked Issue(s)

Closes #49 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
