### PR TITLE
fix small mistype for dataspace name in adopter docs

### DIFF
--- a/content/en/documentation/for-adopters/dataspaces/_index.md
+++ b/content/en/documentation/for-adopters/dataspaces/_index.md
@@ -48,7 +48,7 @@ EDC is designed as a lightweight, non-resource-intensive engine. EDC adds no ove
 
 There is no such thing as cross-dataspace communication. All data sharing takes place within a dataspace. However, that does not mean there is no such thing as dataspace *interoperability*. Let's unpack this.
 
-Consider two dataspaces, DS-1 and DS-B. It's possible for a participant P-A, a member of DS-1, to share data with P-B, a member of DS-2, under one of the following conditions:
+Consider two dataspaces, DS-1 and DS-2. It's possible for a participant P-A, a member of DS-1, to share data with P-B, a member of DS-2, under one of the following conditions:
 - P-A is also a member of DS-2, or
 - P-B is also a member of DS-1
 


### PR DESCRIPTION
## What this PR changes/adds

Documentation, adopter, dataspaces. Change DS-B to DS-2.

## Why it does that

The description after this in the documentation mention DS-2 not DS-B. Probably small mistype.

## Further notes

Non code change. Small fix on documentation only.

## Who will sponsor this feature?

Non feature change.

## Linked Issue(s)

No issue.

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
