### PR TITLE
build: document developer tools

### DIFF
--- a/content/en/documentation/for-contributors/_index.md
+++ b/content/en/documentation/for-contributors/_index.md
@@ -256,50 +256,7 @@ Please find general best practices and recommendations [here](./best-practices.m
 
 ## 6. Further concepts
 
-### 6.1 Autodoc
-
-In EDC there is an automated way to generate basic documentation about extensions, plug points, SPI modules and
-configuration settings. To achieve this, simply annotate respective elements directly in Java code:
-
-```java
-@Extension(value = "Some supercool extension", categories = {"category1", "category2"})
-public class SomeSupercoolExtension implements ServiceExtension {
-
-  // default value -> not required
-  @Setting(value = "Some string config property", type = "string", defaultValue = "foobar", required = false)
-  public static final String SOME_STRING_CONFIG_PROPERTY = "edc.some.supercool.string";
-
-  //no default value -> required
-  @Setting(value = "Some numeric config", type = "integer", required = true)
-  public static final String SOME_INT_CONFIG_PROPERTY = "edc.some.supercool.int";
-
-  // ...
-}
-```
-
-during compilation, the EDC build plugin generates documentation for each module as structured JSON.
-
-Detailed information about autodoc can be found [here](./autodoc.md)
-
-### 6.2 Adapting the Gradle build
-
-The EDC build process is based on Gradle and as such uses several plugins to customize the build and centralize certain
-functionality. One of these plugins has already been [discussed in the previous chapter](#62-autodoc). All of EDC's
-plugins are hosted in the [GradlePlugins repository](https://github.com/eclipse-edc/GradlePlugins).
-
-The most important plugin is the "EDC build" plugin. It consists essentially of these things:
-
-- _a plugin class_: extends `Plugin<Project>` from the Gradle API to hook into the Gradle task infrastructure
-- _extensions_: they are POJOs that are model classes for configuration.
-- _conventions_: individual mutations that are applied to the project. For example, we use conventions to add some
-  standard repositories to all projects, or to implement publishing to Snapshot Repository and MavenCentral in a generic way.
-- _tasks_: executable Gradle tasks that perform a certain action like merging OpenAPI Specification documents.
-
-It is important to note that a Gradle build is separated in _phases_, namely _Initialization_, _Configuration_ and
-_Execution_ (see [documentation](https://docs.gradle.org/current/userguide/build_lifecycle.html)). Some of our
-_conventions_ as well as other plugins have to be applied in the _Configuration_ phase.
-
-### 6.3 The EDC Release process
+### 6.1 The EDC Release process
 
 Generally speaking, EDC publishes `-SNAPSHOT` build artifacts to Snapshot Repository and release build artefacts to
 MavenCentral.
@@ -309,7 +266,7 @@ IdentityHub and FederatedCatalog as well as the RuntimeMetamodel and the aforeme
 comprised up of technology-specific implementations of core SPIs, for example cloud-based object storage or `Vault`
 implementations.
 
-#### 6.3.1 Releasing "core" modules
+#### 6.1.1 Releasing "core" modules
 
 The build processes for two module classes are separated from one another. All modules in the "core" class are published
 under the same Maven group-id `org.eclipse.edc`. This makes it necessary to publish them all at the same time, because
@@ -327,7 +284,7 @@ artifact names remain unchanged.
 This functionality is implemented in the [Release repository](https://github.com/eclipse-edc/Release), which also
 contains GitHub Actions workflows to publish snapshots, nightly builds and release builds.
 
-#### 6.3.2 Releasing "technology" modules
+#### 6.1.2 Releasing "technology" modules
 
 Building and publishing releases for "technology" modules is much simpler, because they do not have to be built together
 with any other repository. With them, we can employ a conventional build-and-publish approach.


### PR DESCRIPTION
## What this PR changes/adds

Move the plugins documentation into a `developer-tools` page.

## Why it does that

Documentation clarity

## Further notes

- I didn't got into the details of the current documentation, just moved things around, there could be something to update, but this work has been done to set the stage for a proper release documentation


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
