### PR TITLE
fix: broken links, exclude decision records

### DIFF
--- a/.github/workflows/check-broken-links.yaml
+++ b/.github/workflows/check-broken-links.yaml
@@ -46,6 +46,7 @@ jobs:
             --exclude-path "node_modules"
             --exclude-path "themes"
             --exclude-path "static/lib"
+            --exclude-path "developer/decision-records"
             --scheme "https"
             --scheme "http"
             --max-retries 6

--- a/content/en/documentation/for-adopters/distributions-deployment-operations/_index.md
+++ b/content/en/documentation/for-adopters/distributions-deployment-operations/_index.md
@@ -7,16 +7,18 @@ weight: 70
 ## Using Bills-of-Material (BOMs)
 
 In the Maven/Gradle world, _bills-of-material_ are meta-modules with the sole purpose of declaring dependencies onto other modules. This greatly reduces the number of dependencies a developer needs to declare. By simply referencing the BOM module, all transitive dependencies are also referenced. The Eclipse Dataspace Components project [declares several BOMs](https://search.maven.org/search?q=g:org.eclipse.edc%20AND%20bom). The most important ones are listed here:
+
 - `controlplane-base-bom`: base BOM for an EDC control plane without an `IdentityService` implementation. Attempting to run this directly will result in an exception
 - `controlplane-dcp-bom`: controlplane that uses [DCP](https://github.com/eclipse-dataspace-dcp/decentralized-claims-protocol) as identity system
 - `dataplane-base-bom`: runnable data plane image that contains HTTP transfer pipelines
 
 **FederatedCatalog:**
+
 - `federatedcatalog-base-bom`: base BOM for FC modules. Does not contain any `IdentityService` implementation
 - `federatedcatalog-dcp-bom`: adds DCP to the FederatedCatalog base BOM
 
-
 **IdentityHub:**
+
 - `identityhub-base-bom`: base BOM for IdentityHub. No DCP modules included
 - `identityhub-bom`: default IdentityHub runtime image including DCP. Does not include/embed the SecureTokenService (STS).
 - `identityhub-with-sts-bom`: IdentityHub runtime that has a SecureTokenService (STS) embedded.
@@ -25,7 +27,7 @@ In addition, most components also provide a `*-feature-sql-bom` BOM, which simpl
 
 ## Using the Basic Template Repository to Create Distributions
 
-The [Modules, Runtimes, and Components](../modules-runtimes-components/_index.md) chapter explained how EDC is built on a module system. Runtimes are assembled to create a *component* such as a control plane, a data plane, or an identity hub. EDC itself does not ship runtime distributions since it is the job of downstream projects to bundle features and capabilities that address the specific requirements of a dataspace or organization.  However, EDC provides the [Basic Template Repository](https://github.com/eclipse-edc/Template-Basic) to facilitate creating extensions and runtime distributions.
+The [Modules, Runtimes, and Components](../modules-runtimes-components/_index.md) chapter explained how EDC is built on a module system. Runtimes are assembled to create a _component_ such as a control plane, a data plane, or an identity hub. EDC itself does not ship runtime distributions since it is the job of downstream projects to bundle features and capabilities that address the specific requirements of a dataspace or organization. However, EDC provides the [Basic Template Repository](https://github.com/eclipse-edc/Template-Basic) to facilitate creating extensions and runtime distributions.
 
 The EDC Basic Template Repository can be forked and used as a starting point for building an EDC distribution. You will need to be familiar with Maven Repositories and [Gradle](https://gradle.org/). Once the repository is forked, custom extensions can be added and included in a runtime. The template is configured to create two runtime Docker images: a control plane and data plane. These images are designed to be deployed as separate processes, such as two Kubernetes `Replicasets`.
 
@@ -49,7 +51,8 @@ The first question that needs to be assessed is: How is your organization struct
 
 Now, let's look at a more complex case in which a multinational organization delegates data-sharing responsibilities to individual units. Each unit has its own IT department and data centers. In this setup, EDC components must be deployed and managed separately. This will impact control planes, data planes, and Identity Hubs. For example, the company could operate a central Identity Hub to manage organizational credentials and delegate control plane and data plane operations to the units. This requires a more complex deployment architecture where control and data planes may be hosted in separate environments, such as multiple cloud tenants.
 
-To accommodate diverse deployment requirements, EDC supports *management domains.* A management domain is ***a realm of control over a set of EDC components***. Management domains enable the operational responsibility of EDC components to be delegated throughout an organization. The following components may be included in a single management domain or spread across multiple domains:
+To accommodate diverse deployment requirements, EDC supports _management domains._ A management domain is **_a realm of control over a set of EDC components_**. Management domains enable the operational responsibility of EDC components to be delegated throughout an organization. The following components may be included in a single management domain or spread across multiple domains:
+
 - Catalog Server
 - Control Plane
 - Data Plane
@@ -64,15 +67,15 @@ can be deployed to a single, collocated process (management domains are represen
 
 ![](single.instance.svg)
 
-***Type 1: One management domain controlling a single instance***
+**_Type 1: One management domain controlling a single instance_**
 
 More complex operational environments may deploy EDC components as separate clustered instances under the operational
-control of a single management domain. For example, a Kubernetes cluster could be deployed with separate *ReplicateSets*
+control of a single management domain. For example, a Kubernetes cluster could be deployed with separate _ReplicateSets_
 running pods of catalog servers, control planes, and data planes:
 
 ![](cluster.svg)
 
-***Type 1: One management domain controlling a cluster of individual ReplicaSets***
+**_Type 1: One management domain controlling a cluster of individual ReplicaSets_**
 
 ### Type 2: Distributed Management Domains
 
@@ -80,7 +83,7 @@ Single management domain topologies are not practical in organizations with inde
 
 Consider the example of a large multinational conglomerate, Foo Industries, which supplies parts for widget production. Foo Industries has separate geographic divisions for production. Each division is responsible for sharing its supply chain data with Foo's partners as part of the Widget-X Dataspace. Foo Industries participates under a single corporate identity in the dataspace, in this case using the Web DID `did:web:widget-x.foo.com`. Some partners may have access to only one of Foo's divisions.
 
-Foo Industries can support this scenario by adopting a ***distributed management domain topology***. There are several different ways to distribute management domains.
+Foo Industries can support this scenario by adopting a **_distributed management domain topology_**. There are several different ways to distribute management domains.
 
 #### Type 2A: DSP Catalog Referencing EDC Stacks
 
@@ -88,7 +91,7 @@ Let's take the simplest to start: each division deploys an EDC component stack. 
 
 ![](distributed-type2a.svg)
 
-***Type 2A: Distributed Management Domains containing an EDC stack***
+**_Type 2A: Distributed Management Domains containing an EDC stack_**
 
 Here, two primary management domains contain a full EDC stack each. A root catalog (explained below) serves as the main entry point for client requests.
 
@@ -98,7 +101,7 @@ Foo Industries could also choose to deploy EDC components in separate management
 
 ![](distributed-type2b.svg)
 
-***Type 2B: Distributed Management Domains containing a Catalog Server and separate Control/Data Plane runtimes***
+**_Type 2B: Distributed Management Domains containing a Catalog Server and separate Control/Data Plane runtimes_**
 
 #### Type 2C: Catalog Server/Control Plane with Data Plane Runtime
 
@@ -106,7 +109,7 @@ Or, Foo Industries could elect to run a centralized catalog server/control plane
 
 ![](distributed-type2c.svg)
 
-***Type 2C: Distributed Management Domains containing a Catalog Server/Control Plane and separate Data Plane runtimes***
+**_Type 2C: Distributed Management Domains containing a Catalog Server/Control Plane and separate Data Plane runtimes_**
 
 ### Identity Hub
 
@@ -114,7 +117,7 @@ The primary deployment scenario for Identity Hub is to run it as a central compo
 
 ### Setting Up Management Domains
 
-Management domains are straightforward to configure as they mainly involve catalog setup. Recall how catalogs are structured as described in the chapter on [Control Plane concepts](Control Plane Concepts.md). Catalogs contain *datasets*, *distributions*, and *data services*. Distributions define the wire protocol used to transfer data and refer to a data service endpoint where a contract agreement can be negotiated to access the data. What was not mentioned is that a catalog is a dataset, which means catalogs can contain sub-catalogs. EDC takes advantage of this to implement management domains using linked catalogs. Here's an example of a catalog with a linked sub-catalog:
+Management domains are straightforward to configure as they mainly involve catalog setup. Recall how catalogs are structured as described in the chapter on [Control Plane concepts](Control Plane Concepts.md). Catalogs contain _datasets_, _distributions_, and _data services_. Distributions define the wire protocol used to transfer data and refer to a data service endpoint where a contract agreement can be negotiated to access the data. What was not mentioned is that a catalog is a dataset, which means catalogs can contain sub-catalogs. EDC takes advantage of this to implement management domains using linked catalogs. Here's an example of a catalog with a linked sub-catalog:
 
 ```json
 {
@@ -122,14 +125,10 @@ Management domains are straightforward to configure as they mainly involve catal
   "@id": "urn:uuid:3afeadd8-ed2d-569e-d634-8394a8836d57",
   "@type": "dcat:Catalog",
   "dct:title": "Foo Industries Provider Root Catalog",
-  "dct:description": [
-    "A catalog of catalogs"
-  ],
+  "dct:description": ["A catalog of catalogs"],
   "dcat:catalog": {
     "@type": "dcat:Catalog",
-	"dct:description": [
-	   "Foo Industries Sub-Catalog"
-	],
+    "dct:description": ["Foo Industries Sub-Catalog"],
     "dcat:distribution": {
       "@type": "dcat:Distribution",
       "dcat:accessService": "urn:uuid:4aa2dcc8-4d2d-569e-d634-8394a8834d77"
@@ -166,7 +165,7 @@ Datasets are created from assets. The same is true for linked catalogs. Adding t
 }
 ```
 
-There are two things to note. First, the `@type` is set to CatalogAsset (which Json-Ld expands to `https://w3id.org/edc/v0.0.1/ns/CatalogAsset`).  Second, the `baseUrl` of the data address is set to the sub-catalog's ***publicly accessible*** URL.
+There are two things to note. First, the `@type` is set to CatalogAsset (which Json-Ld expands to `https://w3id.org/edc/v0.0.1/ns/CatalogAsset`). Second, the `baseUrl` of the data address is set to the sub-catalog's **_publicly accessible_** URL.
 
 The next step in creating a sub-catalog is to decide on access control, that is, which clients can see the sub-catalog. Recall that this is done with a contract definition. A contract definition can have an empty policy ("allow all") or require specific credentials. It can also apply to (select) all sub-catalogs, sub-catalogs containing a specified property value, or a specific sub-catalog. The following contract definition applies an access policy and selects the previous sub-catalog:
 
@@ -185,7 +184,7 @@ The next step in creating a sub-catalog is to decide on access control, that is,
       "edc:operandLeft": "id",
       "edc:operator": "in",
       "edc:operandRight": ["subcatalog-id"]
-    },
+    }
   ]
 }
 ```
@@ -207,7 +206,7 @@ Alternatively, the following contract definition example selects a group of sub-
       "edc:operandLeft": "region",
       "edc:operator": "=",
       "edc:operandRight": "EU"
-    },
+    }
   ]
 }
 ```
@@ -224,10 +223,10 @@ Management domains help align a deployment architecture with an organization's g
 
 Two design considerations are important here. First, as explained in the chapter on [Control Plane concepts](Control Plane Concepts.md), do not model assets in a granular fashion. For example, if data consists of a series of small JSON objects, don't model those as individual assets requiring separate contract negotiations and transfer processes. Instead, model the data as a single asset that can be requested using a single contract agreement through an API.
 
-The second consideration entails how best to optimize data plane performance. In the previous example, the data plane will likely need to be much more performant than the control plane since the request rate will be significantly greater. This means that the data plane will also need to be scaled independently. Consequently, the data plane should be deployed separately from the control plane, for example, as a Kubernetes *ReplicaSet* running on a dedicated cluster.
+The second consideration entails how best to optimize data plane performance. In the previous example, the data plane will likely need to be much more performant than the control plane since the request rate will be significantly greater. This means that the data plane will also need to be scaled independently. Consequently, the data plane should be deployed separately from the control plane, for example, as a Kubernetes _ReplicaSet_ running on a dedicated cluster.
 
 ### Component High Availability
 
 Another consideration that will impact deployment architecture is availability requirements. Consider this carefully. High availability is different from reliability. High availability measures uptime, while reliability measures correctness, i.e., did the system handle an operation in the expected manner? All EDC components are designed to be reliable. For example, remote messages are de-duplicated and handled transactionally.
 
-High availability is instead a function of an organization's requirements. A data plane must often be highly available, particularly if a shared data stream should not be subject to outages. However, a control plane may not need the same guarantees. For example, it may be acceptable for contract negotiations to be temporarily offline as long as data plane operations continue uninterrupted. It may be better to minimize costs by deploying a control plane to less robust infrastructure than a data plane.  There is no hard-and-fast rule here, so you will need to decide on the approach that best addresses your organization's requirements.
+High availability is instead a function of an organization's requirements. A data plane must often be highly available, particularly if a shared data stream should not be subject to outages. However, a control plane may not need the same guarantees. For example, it may be acceptable for contract negotiations to be temporarily offline as long as data plane operations continue uninterrupted. It may be better to minimize costs by deploying a control plane to less robust infrastructure than a data plane. There is no hard-and-fast rule here, so you will need to decide on the approach that best addresses your organization's requirements.

--- a/content/en/documentation/for-contributors/guidelines/_index.md
+++ b/content/en/documentation/for-contributors/guidelines/_index.md
@@ -8,26 +8,27 @@ Thank you for your interest in the EDC! This document provides guidelines and st
 contributing to the project.
 
 <!-- TOC -->
-  * [Code Of Conduct](#code-of-conduct)
-  * [How to Contribute](#how-to-contribute)
-    * [Creating an Issue](#creating-an-issue)
-    * [Submitting a Pull Request](#submitting-a-pull-request)
-      * [Eclipse Contributor Agreement](#eclipse-contributor-agreement)
-    * [Stale Issues and PRs](#stale-issues-and-prs)
-    * [Reporting Flaky Tests](#reporting-flaky-tests)
-  * [Non-Code Contributions](#non-code-contributions)
-  * [Project and Milestone Planning](#project-and-milestone-planning)
-    * [Milestones](#milestones)
-      * [Issues](#issues)
-      * [Pull Requests](#pull-requests)
-    * [Projects](#projects)
-  * [Contact Us](#contact-us)
+
+- [Code Of Conduct](#code-of-conduct)
+- [How to Contribute](#how-to-contribute)
+  - [Creating an Issue](#creating-an-issue)
+  - [Submitting a Pull Request](#submitting-a-pull-request)
+    - [Eclipse Contributor Agreement](#eclipse-contributor-agreement)
+  - [Stale Issues and PRs](#stale-issues-and-prs)
+  - [Reporting Flaky Tests](#reporting-flaky-tests)
+- [Non-Code Contributions](#non-code-contributions)
+- [Project and Milestone Planning](#project-and-milestone-planning)
+  - [Milestones](#milestones)
+    - [Issues](#issues)
+    - [Pull Requests](#pull-requests)
+  - [Projects](#projects)
+- [Contact Us](#contact-us)
 <!-- TOC -->
 
 ## Code Of Conduct
 
 All community members are expected to adhere to
-the [Eclipse Code of Conduct](https://www.eclipse.org/org/documents/Community_Code_of_Conduct.php").
+the [Eclipse Code of Conduct](https://www.eclipse.org/org/documents/Community_Code_of_Conduct.php).
 
 ## How to Contribute
 
@@ -39,7 +40,7 @@ see if it has already been raised. If not, open a discussion (not an issue).
 - For general topics (including project planning, relationship to other projects, etc.) use the [EDC
   organization discussions](https://github.com/orgs/eclipse-edc/discussions).
 - To get a list of issues whereas a new contributor you can contribute to, please take a look at
-  [this page](https://github.com/search?q=org%3Aeclipse-edc+label%3A%22good+first+issue%22+state%3Aopen&type=issues&ref=advsearch). 
+  [this page](https://github.com/search?q=org%3Aeclipse-edc+label%3A%22good+first+issue%22+state%3Aopen&type=issues&ref=advsearch).
 
 ### Creating an Issue
 
@@ -58,12 +59,12 @@ a new issue in the appropriate GitHub repository. Keep in mind the following:
 
 Before submitting code to EDC, you should complete the following prerequisites:
 
-* **DO NOT** submit a PR without first filing an issue (bug) or opening a discussion (new feature).
-* Have a thorough understanding of the EDC codebase, including all technical documentation and Decision Records in the
+- **DO NOT** submit a PR without first filing an issue (bug) or opening a discussion (new feature).
+- Have a thorough understanding of the EDC codebase, including all technical documentation and Decision Records in the
   relevant repositories.
-* Review the [Eclipse Project Handbook](https://www.eclipse.org/projects/handbook/#contributing).
-* Review the [EDC Pull-Request Etiquette](pr-etiquette).
-* Follow the [EDC Pull-Request Checklist](pr-checklist).
+- Review the [Eclipse Project Handbook](https://www.eclipse.org/projects/handbook/#contributing).
+- Review the [EDC Pull-Request Etiquette](pr-etiquette).
+- Follow the [EDC Pull-Request Checklist](pr-checklist).
 
 #### Eclipse Contributor Agreement
 
@@ -76,14 +77,13 @@ an [Eclipse Contributor Agreement (ECA)](http://www.eclipse.org/legal/ecafaq.php
 
 Be sure to use the same email address in your Eclipse Account that you intend to use when committing to GitHub.
 
-
 ### Stale Issues and PRs
 
 In order to keep our backlog clean, EDC uses a bot that labels and closes old issues and PRs. The following table
 outlines this process:
 
 |                        | Stale After | Closed After Stale |
-|:-----------------------|------------:|-------------------:|
+| :--------------------- | ----------: | -----------------: |
 | Issue without assignee |     14 days |             7 days |
 | Issue with assignee    |     28 days |             7 days |
 | PR                     |      7 days |             7 days |
@@ -114,11 +114,11 @@ Note that issues labeled with `Bug` and `FlakyTest` are prioritized.
 Non-code contributions are another valued way to contribute. Examples include:
 
 - Evangelizing EDC
-    - Helping to develop the community by hosting events, meetups, summits, and hackathons
+  - Helping to develop the community by hosting events, meetups, summits, and hackathons
 - Community education
-    - Answering questions on GitHub, Discord, etc.
-    - Writing documentation
-    - Other writing (Blogs, Articles, Interviews)
+  - Answering questions on GitHub, Discord, etc.
+  - Writing documentation
+  - Other writing (Blogs, Articles, Interviews)
 
 ## Project and Milestone Planning
 

--- a/content/en/documentation/for-contributors/metrics.md
+++ b/content/en/documentation/for-contributors/metrics.md
@@ -4,20 +4,22 @@ weight: 250
 ---
 
 <!-- TOC -->
-  * [Micrometer Extension](#micrometer-extension)
-  * [Jetty Micrometer Extension](#jetty-micrometer-extension)
-  * [Jersey Micrometer Extension](#jersey-micrometer-extension)
-  * [Instrumenting ExecutorServices](#instrumenting-executorservices)
-  * [Configuration](#configuration)
+
+- [Micrometer Extension](#micrometer-extension)
+- [Jetty Micrometer Extension](#jetty-micrometer-extension)
+- [Jersey Micrometer Extension](#jersey-micrometer-extension)
+- [Instrumenting ExecutorServices](#instrumenting-executorservices)
+- [Configuration](#configuration)
 <!-- TOC -->
 
 EDC provides extensions for instrumentation with the [Micrometer](https://micrometer.io/) metrics library to automatically collect metrics from the host system, JVM, and frameworks and libraries used in EDC (including OkHttp, Jetty, Jersey and ExecutorService).
 
-See [sample 04.3](https://github.com/eclipse-edc/Samples/blob/main/transfer/transfer-04-open-telemetry/README.md) for an example of an instrumented EDC consumer. 
+See [sample 04.3](https://github.com/eclipse-edc/Samples/tree/main/transfer/transfer-04-event-consumer/README.md) for an example of an instrumented EDC consumer.
 
 ## Micrometer Extension
 
 This extension provides support for instrumentation for some core EDC components:
+
 - JVM metrics
 - [OkHttp](https://square.github.io/okhttp/) client metrics
 - [ExecutorService](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ExecutorService.html) metrics

--- a/content/en/documentation/for-contributors/runtime/json-ld.md
+++ b/content/en/documentation/for-contributors/runtime/json-ld.md
@@ -3,14 +3,13 @@ title: Json LD
 weight: 10
 ---
 
+<!-- TOC -->
 
-<!-- TOC -->
-* [JSON-LD in EDC](#json-ld-in-edc)
-  * [1. JSON-LD in EDC](#1-json-ld-in-edc)
-  * [1.1 Compact IRI](#11-compact-iri)
-  * [1.2 Custom Remote Context](#12-custom-remote-context)
-    * [1.1 JSON-LD Validation](#11-json-ld-validation)
-<!-- TOC -->
+- [JSON-LD in EDC](#1-json-ld-in-edc)
+  - [1. JSON-LD in EDC](#1-json-ld-in-edc)
+  - [1.1 Compact IRI](#11-compact-iri)
+  - [1.2 Custom Remote Context](#12-custom-remote-context) \* [1.1 JSON-LD Validation](#11-json-ld-validation)
+  <!-- TOC -->
 
 Here is a simple example taken from [json-ld.org](https://json-ld.org)
 
@@ -32,7 +31,6 @@ The `@id` is used to uniquely identify an object.
 The `@context` is used to define how [terms](https://www.w3.org/TR/json-ld/#dfn-term) should be interpreted and help
 expressing specific identifier with short-hand names instead
 of [IRI](https://datatracker.ietf.org/doc/html/rfc3987#section-2).
-
 
 > Exhausting reserved keywords list and their meaning is
 > available [here](https://www.w3.org/TR/json-ld11/#syntax-tokens-and-keywords)
@@ -156,12 +154,8 @@ limits the network request required when processing the JSON-LD and reduces the 
 context is compromised.
 
 > By default EDC make usage of [`@vocab`](https://www.w3.org/TR/json-ld/#default-vocabulary) for processing input/output
-> JSON-LD document. This can provide a default vocabulary for extensible properties. An on-going initiative is available
-> with
->
-this [extension](https://github.com/eclipse-edc/Connector/tree/main/extensions/common/api/management-api-json-ld-context)
-> in order to provide a cached terms mapping (context) for EDC management API. The remote context definition is
-> available [here](https://w3id.org/edc/connector/management/v0.0.1).
+> JSON-LD document. This can provide a default vocabulary for extensible properties. The remote context definition is
+> available [on W3ID](https://w3id.org/edc/connector/management/v0.0.1).
 
 Implementors that need additional `@context` and `namespaces` to be supported in EDC runtime, should develop a custom
 extension that registers the required `@context` and `namespace`.
@@ -315,7 +309,7 @@ public class MyExtension implements ServiceExtension {
 ```
 
 With this configuration the JSON-LD will be representend without the `sw` prefix, since the terms mapping is defined in
-the remote context   `http://w3id.org/starwars/context.jsonld`:
+the remote context `http://w3id.org/starwars/context.jsonld`:
 
 ```json
 {


### PR DESCRIPTION
## What this PR changes/adds

this PR fixes some broken links. Some were not actually broken, only reported broken by the tool.

I also excluded the decision records from the check since older decision records contain now-broken links, but
modifying them after the fact technically changes the document... also, it did not seem worth the effort.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
