### PR TITLE
fix: issue creation for broken links

### DIFF
--- a/.github/workflows/check-broken-links-schedule.yaml
+++ b/.github/workflows/check-broken-links-schedule.yaml
@@ -55,15 +55,6 @@ jobs:
           format: markdown
           output: ./lychee-external-report.md
 
-#      - name: Check report content
-#        id: check-report
-#        run: |
-#          if [ -f ./lychee-external-report.md ] && [ -s ./lychee-external-report.md ] && grep -q "Broken links found" ./lychee-external-report.md; then
-#            echo "broken_links=true" >> $GITHUB_OUTPUT
-#          else
-#            echo "broken_links=false" >> $GITHUB_OUTPUT
-#          fi
-
       - name: Create issue
         if: steps.lychee-external.outputs.exit_code != '0'
         uses: peter-evans/create-issue-from-file@v5


### PR DESCRIPTION
## What this PR changes/adds

Fixes the conditional statement for creating an issue with broken link information.

## Further notice

Switched to exit code evaluation rather the report String. Previous check expects a String that never would have been printed in the report, so I guess it is less error-prone to just check the code.

## Why it does that

Currently only a report is created that can be accessed in the Action logs

## Linked Issue(s)

Closes #120 
